### PR TITLE
allow python 3.9

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 build:
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv
-  number: 0
+  number: 1
 
 requirements:
   host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,10 +16,10 @@ build:
 
 requirements:
   host:
-    - python >=3.10
+    - python >=3.9
     - pip
   run:
-    - python >=3.10
+    - python >=3.9
     - numpy >=1.22
     - numba >=0.56
     - matplotlib-base >=3.5


### PR DESCRIPTION
Hello! Based on [pypi](https://pypi.org/project/glasbey/), it looks like version 0.2.0 supports python 3.9, so I am proposing to allow the same on conda-forge. Please feel free to close if I misunderstood.

Thanks for a great package!

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
